### PR TITLE
cleanup imports and copy pasted code

### DIFF
--- a/src/main/java/com/bruberu/gregtechfoodoption/ClientProxy.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/ClientProxy.java
@@ -1,22 +1,12 @@
 package com.bruberu.gregtechfoodoption;
 
-import codechicken.lib.util.ItemNBTUtils;
-import com.bruberu.gregtechfoodoption.integration.appleskin.GTFOMetaFoodHelper;
 import com.bruberu.gregtechfoodoption.integration.appleskin.GTFOMetaTooltipOverlay;
 import com.bruberu.gregtechfoodoption.item.GTFOOredictItem;
 import com.bruberu.gregtechfoodoption.utils.GTFOLog;
-import gregicadditions.item.GADustItem;
-import gregicadditions.materials.SimpleDustMaterial;
 import gregtech.api.unification.OreDictUnifier;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.color.IBlockColor;
-import net.minecraft.client.renderer.color.IItemColor;
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.world.IBlockAccess;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.Loader;
@@ -25,7 +15,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.io.IOException;
 import java.util.Optional;
 
 @SideOnly(Side.CLIENT)

--- a/src/main/java/com/bruberu/gregtechfoodoption/CommonProxy.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/CommonProxy.java
@@ -1,40 +1,29 @@
 package com.bruberu.gregtechfoodoption;
 
-import com.bruberu.gregtechfoodoption.GregTechFoodOption;
 import com.bruberu.gregtechfoodoption.fluid.GTFOMetaFluids;
 import com.bruberu.gregtechfoodoption.integration.GTFOAAMaterialHandler;
 import com.bruberu.gregtechfoodoption.integration.GTFONCMaterialHandler;
 import com.bruberu.gregtechfoodoption.item.GTFOMetaItems;
-import com.bruberu.gregtechfoodoption.item.GTFOOredictItem;
 import com.bruberu.gregtechfoodoption.machines.GTFOTileEntities;
 import com.bruberu.gregtechfoodoption.potion.GTFOPotions;
 import com.bruberu.gregtechfoodoption.recipe.GTFORecipeAddition;
 import com.bruberu.gregtechfoodoption.recipe.GTFORecipeRemoval;
 import com.bruberu.gregtechfoodoption.utils.GTFOLog;
-import gregicadditions.GAMaterials;
-import gregicadditions.Gregicality;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.common.blocks.VariantItemBlock;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.crafting.IRecipe;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Config;
 import net.minecraftforge.common.config.ConfigManager;
 import net.minecraftforge.event.RegistryEvent;
-import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.PlayerEvent;
 import net.minecraftforge.registries.IForgeRegistry;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 

--- a/src/main/java/com/bruberu/gregtechfoodoption/GTFOConfig.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/GTFOConfig.java
@@ -1,11 +1,6 @@
 package com.bruberu.gregtechfoodoption;
 
 import net.minecraftforge.common.config.Config;
-import net.minecraftforge.fluids.FluidRegistry;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 @Config(modid = GregTechFoodOption.MODID)
 

--- a/src/main/java/com/bruberu/gregtechfoodoption/GTFOSeedDropsEventHandler.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/GTFOSeedDropsEventHandler.java
@@ -1,6 +1,5 @@
 package com.bruberu.gregtechfoodoption;
 
-import net.minecraft.client.renderer.block.model.Variant;
 import net.minecraft.init.Blocks;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -13,7 +12,7 @@ import static com.bruberu.gregtechfoodoption.item.GTFOMetaItem.LIME;
 
 public class GTFOSeedDropsEventHandler {
 
-    private Random rand = new Random();
+    private final Random rand = new Random();
 
     @SubscribeEvent
     public void addSeeds(BlockEvent.HarvestDropsEvent event)

--- a/src/main/java/com/bruberu/gregtechfoodoption/GregTechFoodOption.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/GregTechFoodOption.java
@@ -20,24 +20,12 @@ import java.io.IOException;
 public class GregTechFoodOption {
     public static final String MODID = "gregtechfoodoption";
     public static final String NAME = "GregTech Food Option";
-    public static final String VERSION = "@1.12@";
-
-    /*
-    static {
-        if (FMLCommonHandler.instance().getSide().isClient()) {
-
-        }
-    }
-    */
-
+    public static final String VERSION = "@VERSION@";
 
 
     @SidedProxy(modId = MODID, clientSide = "com.bruberu.gregtechfoodoption.ClientProxy", serverSide = "com.bruberu.gregtechfoodoption.CommonProxy")
     public static CommonProxy proxy;
 
-    public GregTechFoodOption() {
-
-    }
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -59,12 +47,5 @@ public class GregTechFoodOption {
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent event) {
 
-    }
-
-    @Mod.EventHandler
-    public void serverStarted(FMLServerStartedEvent event) {
-        if (FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER) {
-            World world = FMLCommonHandler.instance().getMinecraftServerInstance().getEntityWorld();
-        }
     }
 }

--- a/src/main/java/com/bruberu/gregtechfoodoption/client/GTFOClientHandler.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/client/GTFOClientHandler.java
@@ -1,11 +1,6 @@
 package com.bruberu.gregtechfoodoption.client;
 
-import com.bruberu.gregtechfoodoption.GregTechFoodOption;
 import gregtech.api.render.OrientedOverlayRenderer;
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.relauncher.Side;
-
-@Mod.EventBusSubscriber(modid = GregTechFoodOption.MODID, value = Side.CLIENT)
 
 public class GTFOClientHandler {
     public static OrientedOverlayRenderer SLICER_OVERLAY = new OrientedOverlayRenderer("machines/slicer", OrientedOverlayRenderer.OverlayFace.FRONT, OrientedOverlayRenderer.OverlayFace.TOP);

--- a/src/main/java/com/bruberu/gregtechfoodoption/machines/GTFOTileEntities.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/machines/GTFOTileEntities.java
@@ -3,24 +3,18 @@ package com.bruberu.gregtechfoodoption.machines;
 import com.bruberu.gregtechfoodoption.GregTechFoodOption;
 import com.bruberu.gregtechfoodoption.client.GTFOClientHandler;
 import com.bruberu.gregtechfoodoption.recipe.GTFORecipeMaps;
-import de.ellpeck.actuallyadditions.mod.tile.TileEntityBioReactor;
-import gregicadditions.client.ClientHandler;
-import gregicadditions.gui.GAGuiTextures;
 import gregicadditions.machines.GATileEntities;
 import gregicadditions.machines.overrides.GASimpleMachineMetaTileEntity;
-import gregicadditions.recipes.GARecipeMaps;
-import gregtech.api.GTValues;
 import gregtech.api.GregTechAPI;
-import gregtech.api.metatileentity.ITieredMetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
 import net.minecraft.util.ResourceLocation;
 
-/* Takes up IDs 8500 - 8599 */
+import static gregicadditions.machines.GATileEntities.create;
 
+/* Takes up IDs 8500 - 8599 */
 public class GTFOTileEntities {
     public static MetaTileEntityBioReactor[] BIOREACTOR = new MetaTileEntityBioReactor[14];
-    public static GTFOTileEntities.MTE<?>[] SLICER = new GTFOTileEntities.MTE[14];
+    public static GATileEntities.MTE<?>[] SLICER = new GATileEntities.MTE[14];
 
 
     public static void init() {
@@ -43,34 +37,7 @@ public class GTFOTileEntities {
         SLICER[12] = create(8515, new GASimpleMachineMetaTileEntity(location("slicer.uxv"), GTFORecipeMaps.SLICER_RECIPES, GTFOClientHandler.SLICER_OVERLAY, 13));
     }
 
-
-    public static class MTE<T extends MetaTileEntity & ITieredMetaTileEntity> {
-
-        private final T t;
-
-        MTE(T t) {
-            this.t = t;
-        }
-
-        public MetaTileEntity getMetaTileEntity() {
-            return t;
-        }
-
-        public ITieredMetaTileEntity getITieredMetaTileEntity() {
-            return t;
-        }
-    }
-
-
-    public static <T extends MetaTileEntity & ITieredMetaTileEntity> MTE<T> create(int id, T sampleMetaTileEntity) {
-        return new MTE<>(GregTechAPI.registerMetaTileEntity(id, sampleMetaTileEntity));
-    }
-
     public static ResourceLocation location(String name) {
         return new ResourceLocation(GregTechFoodOption.MODID, name);
-    }
-
-    private static ResourceLocation gregtechId(String name) {
-        return new ResourceLocation(GTValues.MODID, name);
     }
 }

--- a/src/main/java/com/bruberu/gregtechfoodoption/machines/MetaTileEntityBioReactor.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/machines/MetaTileEntityBioReactor.java
@@ -1,23 +1,13 @@
 package com.bruberu.gregtechfoodoption.machines;
 
 import gregicadditions.client.ClientHandler;
-import gregicadditions.integrations.exnihilocreatio.machines.MetaTileEntitySieve;
-import gregicadditions.machines.TileEntitySteamMixer;
 import gregicadditions.recipes.GARecipeMaps;
 import gregtech.api.capability.impl.FluidTankList;
-import gregtech.api.gui.GuiTextures;
-import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.LabelWidget;
-import gregtech.api.gui.widgets.ProgressWidget;
-import gregtech.api.gui.widgets.SlotWidget;
-import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.metatileentity.ITieredMetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
-import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;

--- a/src/main/java/com/bruberu/gregtechfoodoption/recipe/GTFOMachineRecipes.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/recipe/GTFOMachineRecipes.java
@@ -1,18 +1,14 @@
 package com.bruberu.gregtechfoodoption.recipe;
 
-import com.bruberu.gregtechfoodoption.machines.GTFOTileEntities;
-import gregicadditions.recipes.helper.GACraftingComponents;
 import gregtech.api.items.OreDictNames;
-import gregtech.api.metatileentity.ITieredMetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.recipes.ModHandler;
-import gregtech.api.unification.OreDictUnifier;
-
-import java.util.Arrays;
+import gregtech.api.unification.stack.UnificationEntry;
 
 import static com.bruberu.gregtechfoodoption.machines.GTFOTileEntities.BIOREACTOR;
 import static com.bruberu.gregtechfoodoption.machines.GTFOTileEntities.SLICER;
 import static gregicadditions.recipes.helper.GACraftingComponents.*;
+import static gregicadditions.recipes.helper.HelperMethods.*;
+import static gregtech.api.unification.material.Materials.Polytetrafluoroethylene;
+import static gregtech.api.unification.ore.OrePrefix.plate;
 
 public class GTFOMachineRecipes {
     public static void init()
@@ -26,8 +22,8 @@ public class GTFOMachineRecipes {
                 'S', SENSOR,
                 'H', HULL,
                 'G', GLASS,
-                'I', OreDictUnifier.get("platePolytetrafluoroethylene")
-                );
+                'I', new UnificationEntry(plate, Polytetrafluoroethylene)
+        );
         registerMachineRecipe(SLICER,
                 "PCA", "SHC", "LOA",
                 'P', PISTON,
@@ -38,54 +34,5 @@ public class GTFOMachineRecipes {
                 'L', PLATE_DENSE,
                 'O', CONVEYOR
         );
-    }
-
-    /**
-     * Tiered Machine Recipe Registration method.
-     * An example of how to use it:
-     *
-     * <cr>
-     *     registerMachineRecipe(GATileEntities.DIODES,
-     *                 "CCC", "XMX", "CCC",
-     *                 'M', HULL,
-     *                 'C', CABLE_SINGLE,
-     *                 'X', MetaItems.SMALL_COIL);
-     * </cr>
-     *
-     * - The MetaTileEntity input can be an Array, a List, or an Array of
-     * - The Recipe Input must be Strings of up to 3 characters.
-     * - The inputs must be in pairs of (char, [input]).
-     * - Inputs can be a:
-     *     - String representing an OreDictionary entry
-     *     - ItemStack
-     *     - {@link GACraftingComponents} or {@link gregtech.loaders.recipe.CraftingComponent}
-     *     - {@link gregtech.api.unification.stack.UnificationEntry}
-     *
-     * @param ingredientOffset The starting position in the Array or List of MetaTileEntities
-     * @param metaTileEntities The group of MetaTileEntities to register the same recipe for.
-     * @param recipe           The Recipe Layout, detailed above.
-     */
-    public static <T extends MetaTileEntity & ITieredMetaTileEntity> void registerMachineRecipe(int ingredientOffset, T[] metaTileEntities, Object... recipe) {
-        for (T metaTileEntity : metaTileEntities) {
-            if (metaTileEntity != null)
-                ModHandler.addShapedRecipe(String.format("ga_%s", metaTileEntity.getMetaName()), metaTileEntity.getStackForm(),
-                        prepareRecipe(metaTileEntity.getTier() + ingredientOffset, Arrays.copyOf(recipe, recipe.length)));
-        }
-    }
-    private static Object[] prepareRecipe(int tier, Object... recipe) {
-        for (int i = 3; i < recipe.length; i++) {
-            if (recipe[i] instanceof GACraftingComponents) {
-                recipe[i] = ((GACraftingComponents) recipe[i]).getIngredient(tier);
-            }
-        }
-        return recipe;
-    }
-
-    public static void registerMachineRecipe(GTFOTileEntities.MTE<?>[] metaTileEntities, Object... recipe) {
-        for (GTFOTileEntities.MTE<?> metaTileEntity : metaTileEntities) {
-            if (metaTileEntity != null)
-                ModHandler.addShapedRecipe(String.format("ga_%s", metaTileEntity.getMetaTileEntity().getMetaName()), metaTileEntity.getMetaTileEntity().getStackForm(),
-                        prepareRecipe(metaTileEntity.getITieredMetaTileEntity().getTier(), Arrays.copyOf(recipe, recipe.length)));
-        }
     }
 }

--- a/src/main/java/com/bruberu/gregtechfoodoption/utils/GTFOLog.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/utils/GTFOLog.java
@@ -5,7 +5,6 @@ import org.apache.logging.log4j.Logger;
 /**
  * GregTechFoodOption logger
  * One edit to this class and you're not alive anymore
- * :troll:
  */
 public class GTFOLog {
 

--- a/src/main/java/com/bruberu/gregtechfoodoption/utils/GTFOLog.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/utils/GTFOLog.java
@@ -2,10 +2,16 @@ package com.bruberu.gregtechfoodoption.utils;
 
 import org.apache.logging.log4j.Logger;
 
+/**
+ * GregTechFoodOption logger
+ * One edit to this class and you're not alive anymore
+ * :troll:
+ */
 public class GTFOLog {
+
     public static Logger logger;
+
     public static void init(Logger modLogger) {
         logger = modLogger;
     }
-
 }

--- a/src/main/java/com/bruberu/gregtechfoodoption/utils/RecipeUtils.java
+++ b/src/main/java/com/bruberu/gregtechfoodoption/utils/RecipeUtils.java
@@ -1,6 +1,5 @@
 package com.bruberu.gregtechfoodoption.utils;
 
-import com.bruberu.gregtechfoodoption.item.GTFOOredictItem;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.material.type.FluidMaterial;
@@ -8,23 +7,13 @@ import gregtech.api.unification.ore.OrePrefix;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.FurnaceRecipes;
-import net.minecraftforge.fluids.Fluid;
-import net.minecraftforge.fluids.FluidStack;
 
-import java.util.Iterator;
-import java.util.Map;
-
-import static com.bruberu.gregtechfoodoption.GTFOMaterialHandler.FungalGrowthMedium;
-import static com.bruberu.gregtechfoodoption.GTFOMaterialHandler.PhycomycesBlakesleeanus;
-import static com.bruberu.gregtechfoodoption.item.GTFOMetaItem.PHYCOMYCES_BLAKESLEEANUS_CULTURE;
 import static gregicadditions.GAMaterials.DepletedGrowthMedium;
 import static gregicadditions.GAMaterials.OrganicFertilizer;
 import static gregicadditions.item.GAMetaItems.CLEAN_CULTURE;
 import static gregicadditions.item.GAMetaItems.CONTAMINATED_PETRI_DISH;
 import static gregicadditions.recipes.GARecipeMaps.BIO_REACTOR_RECIPES;
 import static gregicadditions.recipes.GARecipeMaps.GREEN_HOUSE_RECIPES;
-import static gregtech.api.unification.material.Materials.Milk;
 import static gregtech.api.unification.material.Materials.Water;
 
 //A not small amount of code from here was yoinked from other places. I'll give credit wherever I can!
@@ -36,7 +25,7 @@ public class RecipeUtils {
         GREEN_HOUSE_RECIPES.recipeBuilder().duration(600).notConsumable(new IntCircuitIngredient(2)).input(OrePrefix.dust, OrganicFertilizer).fluidInputs(Water.getFluid(2000)).notConsumable(seed).outputs(new ItemStack(crop, 3)).chancedOutput(seed, 100, 50).buildAndRegister();
     }
 
-    public static void addGreenHouseRecipes(ItemStack seed, MetaItem.MetaValueItem crop) {
+    public static void addGreenHouseRecipes(ItemStack seed, MetaItem<?>.MetaValueItem crop) {
         GREEN_HOUSE_RECIPES.recipeBuilder().duration(1000).notConsumable(new IntCircuitIngredient(0)).fluidInputs(Water.getFluid(2000)).notConsumable(seed).outputs(crop.getStackForm()).buildAndRegister();
         GREEN_HOUSE_RECIPES.recipeBuilder().duration(900).notConsumable(new IntCircuitIngredient(1)).inputs(new ItemStack(Items.DYE, 1, 15)).fluidInputs(Water.getFluid(2000)).notConsumable(seed).outputs(crop.getStackForm(2)).chancedOutput(seed, 100, 50).buildAndRegister();
         GREEN_HOUSE_RECIPES.recipeBuilder().duration(600).notConsumable(new IntCircuitIngredient(2)).input(OrePrefix.dust, OrganicFertilizer).fluidInputs(Water.getFluid(2000)).notConsumable(seed).outputs(crop.getStackForm(3)).chancedOutput(seed, 100, 50).buildAndRegister();


### PR DESCRIPTION
This PR mostly cleans up a lot of imports and other unused code. I left much of it that I thought you were leaving for the future. Also, I:
- Moved to using the GregicalityAPI for MTE registration
- Moved to using the GregicalityAPI for MTE recipe registration
- Fixed an issue where the version of the mod was not being applied correctly to the Mod annotated class, causing it to not display properly in the in-game modlist