### PR TITLE
Remove unnecessary ItemStack copying and fix state properties

### DIFF
--- a/src/main/java/gregtechfoodoption/block/GTFOBerryBush.java
+++ b/src/main/java/gregtechfoodoption/block/GTFOBerryBush.java
@@ -29,11 +29,12 @@ public class GTFOBerryBush extends GTFOCrop {
     private static final AxisAlignedBB LARGE_AABB = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.9375D, 0.9375D);
     private static final AxisAlignedBB STEM_AABB = new AxisAlignedBB(0.4325D, 0.0D, 0.4325D, 0.5675D, 0.25D, 0.5675D);
 
+    protected static final PropertyInteger DEFAULT_AGE_BUSH = PropertyInteger.create("age", 0, 2);
 
     private boolean isThorny = false;
 
     protected GTFOBerryBush(String name) {
-        super(name, 2);
+        super(name, DEFAULT_AGE_BUSH);
         this.setTranslationKey("gtfo_berry_bush_" + name);
         this.setHardness(1F);
     }
@@ -44,12 +45,11 @@ public class GTFOBerryBush extends GTFOCrop {
     }
 
     public static GTFOBerryBush create(String name) {
-        AGE_TEMP = PropertyInteger.create("age", 0, 2);
         return new GTFOBerryBush(name);
     }
 
     protected BlockStateContainer createBlockState() {
-        return AGE_GTFO == null ? new BlockStateContainer(this, AGE_TEMP, EFFICIENCY_GTFO) : new BlockStateContainer(this, AGE_GTFO, EFFICIENCY_GTFO);
+        return new BlockStateContainer(this, getAgeProperty(), EFFICIENCY_GTFO);
     }
 
     public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune) {
@@ -58,14 +58,17 @@ public class GTFOBerryBush extends GTFOCrop {
         Random rand = world instanceof World ? ((World) world).rand : new Random();
 
         if (age >= this.getMaxAge()) {
-            drops.add(this.crop.copy());
+            int cropCount = 1;
             for (int i = 0; i < 2 + efficiency; ++i) {
                 if (rand.nextInt(2) == 0) {
-                    drops.add(this.crop.copy());
+                    cropCount++;
                 }
             }
-        }
 
+            ItemStack crop = this.crop.copy();
+            crop.setCount(cropCount);
+            drops.add(crop);
+        }
     }
 
     public int getEfficiency(IBlockState state) {
@@ -182,7 +185,7 @@ public class GTFOBerryBush extends GTFOCrop {
             if (!playerIn.addItemStackToInventory(berryStack)) {
                 playerIn.dropItem(this.getCropStack(), false);
             }
-            worldIn.setBlockState(pos, state.withProperty(AGE_GTFO, Integer.valueOf(this.getMaxAge() - 1)), 3);
+            worldIn.setBlockState(pos, state.withProperty(getAgeProperty(), this.getMaxAge() - 1), 3);
             return true;
         }
         return false;
@@ -190,7 +193,7 @@ public class GTFOBerryBush extends GTFOCrop {
 
     @Override
     public IBlockState getStateFromMeta(int meta) {
-        return this.withAge(meta % 3).withProperty(EFFICIENCY_GTFO, Integer.valueOf(meta / 3));
+        return this.withAge(meta % 3).withProperty(EFFICIENCY_GTFO, meta / 3);
     }
 
     @Override

--- a/src/main/java/gregtechfoodoption/block/GTFOBerryBush.java
+++ b/src/main/java/gregtechfoodoption/block/GTFOBerryBush.java
@@ -34,7 +34,7 @@ public class GTFOBerryBush extends GTFOCrop {
     private boolean isThorny = false;
 
     protected GTFOBerryBush(String name) {
-        super(name, DEFAULT_AGE_BUSH);
+        super(name);
         this.setTranslationKey("gtfo_berry_bush_" + name);
         this.setHardness(1F);
     }
@@ -209,5 +209,10 @@ public class GTFOBerryBush extends GTFOCrop {
             worldIn.setBlockState(pos, state.withProperty(EFFICIENCY_GTFO, newEfficiency), 3);
         }
         super.neighborChanged(state, worldIn, pos, blockIn, fromPos);
+    }
+
+    @Override
+    public PropertyInteger getAgeProperty() {
+       return DEFAULT_AGE_BUSH;
     }
 }

--- a/src/main/java/gregtechfoodoption/block/GTFOCrop.java
+++ b/src/main/java/gregtechfoodoption/block/GTFOCrop.java
@@ -19,17 +19,15 @@ import java.util.List;
 import java.util.Random;
 
 public class GTFOCrop extends BlockCrops {
-    protected final PropertyInteger AGE_GTFO;
 
     public static final PropertyInteger DEFAULT_AGE = PropertyInteger.create("age", 0, 5);
     private static final AxisAlignedBB CROPS_AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 0.25D, 1.0D);
     protected ItemStack seed;
     protected ItemStack crop;
     public static List<GTFOCrop> CROP_BLOCKS = new ArrayList<>();
-    private String name;
+    private final String name;
 
-    protected GTFOCrop(String name, PropertyInteger age) {
-        AGE_GTFO = age;
+    protected GTFOCrop(String name) {
         this.setDefaultState(this.blockState.getBaseState().withProperty(this.getAgeProperty(), 0));
         this.setRegistryName(GregTechFoodOption.MODID, "crop_" + name);
         CROP_BLOCKS.add(this);
@@ -37,16 +35,8 @@ public class GTFOCrop extends BlockCrops {
         this.setTranslationKey("gtfo_crop_" + name);
     }
 
-    protected GTFOCrop(String name) {
-        this(name, DEFAULT_AGE);
-    }
-
     public static GTFOCrop create(String name) {
         return new GTFOCrop(name);
-    }
-
-    public static GTFOCrop create(String name, int min, int max) {
-        return new GTFOCrop(name, PropertyInteger.create("age", min, max));
     }
 
     public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
@@ -126,7 +116,7 @@ public class GTFOCrop extends BlockCrops {
 
     @Override
     public PropertyInteger getAgeProperty() {
-        return AGE_GTFO;
+        return DEFAULT_AGE;
     }
 
     protected BlockStateContainer createBlockState() {

--- a/src/main/java/gregtechfoodoption/block/GTFOCrop.java
+++ b/src/main/java/gregtechfoodoption/block/GTFOCrop.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Random;
 
 public class GTFOCrop extends BlockCrops {
-    public final PropertyInteger AGE_GTFO;
+    protected final PropertyInteger AGE_GTFO;
 
     public static final PropertyInteger DEFAULT_AGE = PropertyInteger.create("age", 0, 5);
     private static final AxisAlignedBB CROPS_AABB = new AxisAlignedBB(0.0D, 0.0D, 0.0D, 1.0D, 0.25D, 1.0D);
@@ -125,7 +125,7 @@ public class GTFOCrop extends BlockCrops {
     }
 
     @Override
-    protected PropertyInteger getAgeProperty() {
+    public PropertyInteger getAgeProperty() {
         return AGE_GTFO;
     }
 

--- a/src/main/java/gregtechfoodoption/block/GTFORootCrop.java
+++ b/src/main/java/gregtechfoodoption/block/GTFORootCrop.java
@@ -15,12 +15,13 @@ import net.minecraft.world.World;
 import java.util.Random;
 
 public class GTFORootCrop extends GTFOCrop {
+    protected static final PropertyInteger DEFAULT_AGE_ROOT = PropertyInteger.create("age", 0, 7);
+
     protected GTFORootCrop(String name) {
-        super(name, 7);
+        super(name);
     }
 
     public static GTFORootCrop create(String name) {
-        AGE_TEMP = PropertyInteger.create("age", 0, 7);
         return new GTFORootCrop(name);
     }
 
@@ -67,5 +68,10 @@ public class GTFORootCrop extends GTFOCrop {
         }
 
         return super.onBlockActivated(world, pos, state, playerIn, hand, facing, hitX, hitY, hitZ);
+    }
+
+    @Override
+    public PropertyInteger getAgeProperty() {
+       return DEFAULT_AGE_ROOT;
     }
 }

--- a/src/main/java/gregtechfoodoption/block/GTFOWaterCrop.java
+++ b/src/main/java/gregtechfoodoption/block/GTFOWaterCrop.java
@@ -1,7 +1,5 @@
 package gregtechfoodoption.block;
 
-import net.minecraft.block.material.Material;
-import net.minecraft.block.properties.PropertyInteger;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.AxisAlignedBB;
@@ -13,11 +11,10 @@ public class GTFOWaterCrop extends GTFOCrop {
     protected static final AxisAlignedBB WATER_CROP_AABB = new AxisAlignedBB(0.0625D, 0.0D, 0.0625D, 0.9375D, 0.09375D, 0.9375D);
 
     protected GTFOWaterCrop(String name) {
-        super(name, 5);
+        super(name);
     }
 
     public static GTFOWaterCrop create(String name) {
-        AGE_TEMP = PropertyInteger.create("age", 0, 5);
         return new GTFOWaterCrop(name);
     }
     @Override

--- a/src/main/java/gregtechfoodoption/integration/enderio/GTFOBerryFarmer.java
+++ b/src/main/java/gregtechfoodoption/integration/enderio/GTFOBerryFarmer.java
@@ -60,7 +60,7 @@ public class GTFOBerryFarmer extends CustomSeedFarmer {
             res.addDrop(pos, drop.copy());
         });
 
-        world.setBlockState(pos, state.withProperty(crop.AGE_GTFO, Integer.valueOf(crop.getMaxAge() - 1)), 3);
+        world.setBlockState(pos, state.withProperty(crop.getAgeProperty(), Integer.valueOf(crop.getMaxAge() - 1)), 3);
         return res;
     }
 

--- a/src/main/java/gregtechfoodoption/item/GTFOMetaItem.java
+++ b/src/main/java/gregtechfoodoption/item/GTFOMetaItem.java
@@ -1189,17 +1189,15 @@ public class GTFOMetaItem extends MetaItem<GTFOMetaItem.GTFOMetaValueItem> imple
 
     @Nonnull
     public CreativeTabs[] getCreativeTabs() {
-        return new CreativeTabs[]{GTFOValues.TAB_GTFO, GTFOValues.TAB_GTFO_FOOD};
+        return new CreativeTabs[]{CreativeTabs.SEARCH, GTFOValues.TAB_GTFO, GTFOValues.TAB_GTFO_FOOD};
     }
 
     @SideOnly(Side.CLIENT)
     public void getSubItems(@Nonnull CreativeTabs tab, @Nonnull NonNullList<ItemStack> subItems) {
-        if (tab == GTFOValues.TAB_GTFO || tab == GTFOValues.TAB_GTFO_FOOD) {
-            for (MetaItem.MetaValueItem item : this.getAllItems()) {
-                if (item.isVisible() && ((!(item.getUseManager() instanceof FoodUseManager) && tab == GTFOValues.TAB_GTFO) || ((item.getUseManager() instanceof FoodUseManager) && tab == GTFOValues.TAB_GTFO_FOOD) || tab == CreativeTabs.SEARCH)) {
-                    ItemStack itemStack = item.getStackForm();
-                    item.getSubItemHandler().getSubItems(itemStack, tab, subItems);
-                }
+        for (MetaItem.MetaValueItem item : this.getAllItems()) {
+            if (item.isVisible() && ((!(item.getUseManager() instanceof FoodUseManager) && tab == GTFOValues.TAB_GTFO) || ((item.getUseManager() instanceof FoodUseManager) && tab == GTFOValues.TAB_GTFO_FOOD) || tab == CreativeTabs.SEARCH)) {
+                ItemStack itemStack = item.getStackForm();
+                item.getSubItemHandler().getSubItems(itemStack, tab, subItems);
             }
         }
     }

--- a/src/main/java/gregtechfoodoption/machines/farmer/GTFOBerryFarmerMode.java
+++ b/src/main/java/gregtechfoodoption/machines/farmer/GTFOBerryFarmerMode.java
@@ -21,6 +21,6 @@ public class GTFOBerryFarmerMode implements FarmerMode {
     @Override
     public void harvest(IBlockState state, World world, BlockPos.MutableBlockPos pos, MetaTileEntityFarmer farmer) {
         GTFOCrop crop = (GTFOCrop) state.getBlock();
-        world.setBlockState(pos, state.withProperty(crop.AGE_GTFO, Integer.valueOf(crop.getMaxAge() - 1)), 3);
+        world.setBlockState(pos, state.withProperty(crop.getAgeProperty(), Integer.valueOf(crop.getMaxAge() - 1)), 3);
     }
 }


### PR DESCRIPTION
I removed unnecessary stack copying in getDrops and getSeedStack, and I used ItemStack counts for drops instead. I guess Minecraft adds drops like that but I'm sure it's unnecessary stack generation for no reason and also copy method can be slow because of capabilities.

Also I fixed age properties (AGE_GTFO and AGE_TEMP). AGE_GTFO didn't work because createBlockState is run in super constructor which would end up crashing the game if a plant block used AGE_GTFO, I guess it worked because AGE_TEMP and AGE_GTFO shares the same hash code and equals method. I replaced AGE_TEMP with AGE_DEFAULT and AGE_DEFAULT_BUSH, and use them by default. 

Made AGE_GTFO blocks' property instead of block being able to have two different properties and made it protected and instead opt-in to use getAgeProperty (made it public). It should be easier to handle and understand now.