### PR TITLE
Remove unused local captures, use @Local where needed

### DIFF
--- a/src/main/java/gregtechfoodoption/mixins/early/GuiPlayerTabOverlayMixin.java
+++ b/src/main/java/gregtechfoodoption/mixins/early/GuiPlayerTabOverlayMixin.java
@@ -1,8 +1,8 @@
 package gregtechfoodoption.mixins.early;
 
+import com.llamalad7.mixinextras.sugar.Local;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiPlayerTabOverlay;
-import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.client.network.NetworkPlayerInfo;
 import net.minecraft.scoreboard.ScoreObjective;
 import net.minecraft.scoreboard.Scoreboard;
@@ -10,15 +10,13 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.List;
 
 @Mixin(value = GuiPlayerTabOverlay.class, priority = 500, remap = false)
 public class GuiPlayerTabOverlayMixin {
-    @Inject(method = "renderPlayerlist", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/Ordering;sortedCopy(Ljava/lang/Iterable;)Ljava/util/List;"),
-            cancellable = true, locals = LocalCapture.CAPTURE_FAILHARD)
-    public void youAreAllAlone(int width, Scoreboard scoreboardIn, ScoreObjective scoreObjectiveIn, CallbackInfo ci, NetHandlerPlayClient nethandlerplayclient, List<NetworkPlayerInfo> list) {
+    @Inject(method = "renderPlayerlist", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/Ordering;sortedCopy(Ljava/lang/Iterable;)Ljava/util/List;"))
+    public void youAreAllAlone(int width, Scoreboard scoreboardIn, ScoreObjective scoreObjectiveIn, CallbackInfo ci, @Local List<NetworkPlayerInfo> list) {
         list.removeIf(playerInfo -> !playerInfo.getGameProfile().getId().equals(Minecraft.getMinecraft().player.getPersistentID()));
     }
 }

--- a/src/main/java/gregtechfoodoption/mixins/early/RenderManagerMixin.java
+++ b/src/main/java/gregtechfoodoption/mixins/early/RenderManagerMixin.java
@@ -10,12 +10,10 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(value = RenderManager.class, priority = 500, remap = false)
 public class RenderManagerMixin {
-    @Inject(method = "renderEntity", at = @At("HEAD"),
-            locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
+    @Inject(method = "renderEntity", at = @At("HEAD"), cancellable = true)
     public void removePlayerRender(Entity entityIn, double x, double y, double z, float yaw, float partialTicks, boolean mojangBrainFart, CallbackInfo ci) {
         EntityPlayer player = Minecraft.getMinecraft().player;
         if (player != null && player.isPotionActive(AntiSchizoPotion.INSTANCE) && entityIn instanceof EntityPig && !entityIn.isEntityEqual(player)) {

--- a/src/main/java/gregtechfoodoption/mixins/late/RecipeMapFluidCannerMixin.java
+++ b/src/main/java/gregtechfoodoption/mixins/late/RecipeMapFluidCannerMixin.java
@@ -5,21 +5,17 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.ingredients.GTRecipeItemInput;
 import gregtech.api.recipes.machines.RecipeMapFluidCanner;
 import gregtechfoodoption.item.GTFOFoodStats;
-import gregtechfoodoption.item.GTFOOredictItem;
 import gregtechfoodoption.potion.LacingEntry;
-import gregtechfoodoption.utils.GTFOLog;
 import gregtechfoodoption.utils.GTFOUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.capability.IFluidHandlerItem;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
-import java.util.Iterator;
 import java.util.List;
 
 import static gregtech.api.recipes.RecipeMaps.CANNER_RECIPES;
@@ -33,9 +29,8 @@ public class RecipeMapFluidCannerMixin {
             at = /*@At(value = "JUMP",
                     opcode = Opcodes.GOTO,
                     ordinal = 0),*/
-            @At(value = "RETURN", ordinal = 1),
-            locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
-    private void checkLacingRecipes(long voltage, List inputs, List fluidInputs, boolean exactVoltage, CallbackInfoReturnable<Recipe> cir, Recipe recipe, Iterator var7, ItemStack input, ItemStack inputStack, ItemStack fluidHandlerItemStack, IFluidHandlerItem fluidHandlerItem) {
+            @At(value = "RETURN", ordinal = 1), cancellable = true)
+    private void checkLacingRecipes(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, boolean exactVoltage, CallbackInfoReturnable<Recipe> cir) {
         findLacingRecipe(inputs, fluidInputs, cir);
     }
 
@@ -43,12 +38,12 @@ public class RecipeMapFluidCannerMixin {
             at = /*@At(value = "JUMP",
                     opcode = Opcodes.GOTO,
                     ordinal = 0),*/
-            @At(value = "RETURN", ordinal = 4),
-            locals = LocalCapture.CAPTURE_FAILHARD, cancellable = true)
-    private void checkLacingRecipes2(long voltage, List inputs, List fluidInputs, boolean exactVoltage, CallbackInfoReturnable<Recipe> cir, Recipe recipe) {
+            @At(value = "RETURN", ordinal = 4), cancellable = true)
+    private void checkLacingRecipes2(long voltage, List<ItemStack> inputs, List<FluidStack> fluidInputs, boolean exactVoltage, CallbackInfoReturnable<Recipe> cir) {
         findLacingRecipe(inputs, fluidInputs, cir);
     }
 
+    @Unique
     public void findLacingRecipe(List<ItemStack> inputs, List<FluidStack> fluidInputs, CallbackInfoReturnable<Recipe> cir) {
         ItemStack inputStack = ItemStack.EMPTY;
         ItemStack lacingWith = ItemStack.EMPTY;


### PR DESCRIPTION
This PR:

- removes the unused local captures in mixins, and use @Local from MixinExtras (I like sugar)

the unused local captures in causing some issues when using crl v0.2.3-alpha, this *may* be an issue on either mixin or crl side, but ig it's ok to remove these local captures and use @Local instead.