### PR TITLE
Fixed recipes continuing to work even after the mob left/died and recipes not dealing damage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1723428048
+//version: 1743737794
 /*
  * DO NOT CHANGE THIS FILE!
  * Also, you may replace this file at any time if there is an update available.
@@ -80,6 +80,7 @@ propertyDefaultIfUnset("includeWellKnownRepositories", true)
 propertyDefaultIfUnset("includeCommonDevEnvMods", true)
 propertyDefaultIfUnset("stripForgeRequirements", false)
 propertyDefaultIfUnset("noPublishedSources", false)
+propertyDefaultIfUnset("mixinProviderSpec", "zone.rong:mixinbooter:10.6")
 propertyDefaultIfUnset("forceEnableMixins", false)
 propertyDefaultIfUnset("mixinConfigRefmap", "mixins.${project.modId}.refmap.json")
 propertyDefaultIfUnsetWithEnvVar("enableCoreModDebug", false, "CORE_MOD_DEBUG")
@@ -518,7 +519,6 @@ configurations {
     testRuntimeClasspath.extendsFrom(runtimeOnlyNonPublishable)
 }
 
-String mixinProviderSpec = 'zone.rong:mixinbooter:9.1'
 dependencies {
     if (usesMixins.toBoolean()) {
         annotationProcessor 'org.ow2.asm:asm-debug-all:5.2'
@@ -1009,7 +1009,7 @@ abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
 
         if (project.usesMixins.toBoolean()) {
             this.extraJvmArgs.addAll(project.provider(() -> {
-                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(mixinProviderSpec))
                 mixinCfg.canBeConsumed = false
                 mixinCfg.canBeResolved = true
                 mixinCfg.transitive = false

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -37,7 +37,7 @@ repositories {
     }
     maven {
         name = "mcmoddev"
-        url = "https://maven.mcmoddev.com"
+        url = "https://mcmoddev.com"
     }
     maven {
         name = "ModMaven"

--- a/src/main/java/gregtechfoodoption/machines/MetaTileEntityMobExtractor.java
+++ b/src/main/java/gregtechfoodoption/machines/MetaTileEntityMobExtractor.java
@@ -51,7 +51,7 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
         if (entityRequired == null)
             return true;
 
-        if (this.attackableTarget == null || this.getOffsetTimer() % 5 == 0) {
+        if (this.getOffsetTimer() % 5 == 0) {
             this.nearbyEntities = getEntitiesInProximity();
             for (Entity entity : nearbyEntities) {
                 if (EntityList.isMatchingName(entity, entityRequired)) {
@@ -100,10 +100,11 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
         }
 
         @Override
-        protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
-            ((MetaTileEntityMobExtractor) metaTileEntity).damageEntity(recipe);
-            return super.setupAndConsumeRecipeInputs(recipe, importInventory);
+        protected void setupRecipe(@Nonnull Recipe recipe) {
+        ((MetaTileEntityMobExtractor) metaTileEntity).damageEntity(recipe);
+        super.setupRecipe(recipe);
         }
+
     }
 
 }

--- a/src/main/java/gregtechfoodoption/machines/MetaTileEntityMobExtractor.java
+++ b/src/main/java/gregtechfoodoption/machines/MetaTileEntityMobExtractor.java
@@ -3,7 +3,6 @@ package gregtechfoodoption.machines;
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.impl.RecipeLogicEnergy;
 import gregtech.api.metatileentity.MetaTileEntity;
-import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
 import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
@@ -17,9 +16,9 @@ import gregtechfoodoption.utils.GTFODamageSources;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityList;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.AxisAlignedBB;
-import net.minecraftforge.items.IItemHandlerModifiable;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -28,7 +27,7 @@ import java.util.function.Supplier;
 
 public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity {
     private AxisAlignedBB boundingBox;
-    private EntityLivingBase attackableTarget;
+    private Entity attackableTarget;
     private List<Entity> nearbyEntities;
 
     public MetaTileEntityMobExtractor(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, ICubeRenderer renderer, int tier, boolean hasFrontFacing,
@@ -51,16 +50,14 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
         if (entityRequired == null)
             return true;
 
-        if (this.getOffsetTimer() % 5 == 0) {
-            this.nearbyEntities = getEntitiesInProximity();
-            for (Entity entity : nearbyEntities) {
-                if (EntityList.isMatchingName(entity, entityRequired)) {
-                    if (entity instanceof EntityLivingBase) // Prepare to cause damage if needed.
-                        attackableTarget = (EntityLivingBase) entity;
-                    else
-                        attackableTarget = null;
-                    return true;
-                }
+        this.nearbyEntities = getEntitiesInProximity();
+        if (attackableTarget != null && this.nearbyEntities.contains(attackableTarget)) {
+            return true;
+        }
+        this.attackableTarget = null;
+        for (Entity entity : nearbyEntities) {
+            if (EntityList.isMatchingName(entity, entityRequired)) {
+                attackableTarget = entity;
             }
         }
         return attackableTarget != null;
@@ -69,7 +66,7 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
     protected List<Entity> getEntitiesInProximity() {
         if (boundingBox == null)
             boundingBox = new AxisAlignedBB(this.getPos().up());
-        return this.getWorld().getEntitiesWithinAABB(Entity.class, boundingBox);
+        return this.getWorld().getEntitiesWithinAABB(Entity.class, boundingBox, EntitySelectors.IS_ALIVE);
     }
 
     protected void damageEntity(Recipe recipe) {
@@ -77,9 +74,6 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
             float damage = recipe.getProperty(CauseDamageProperty.getInstance(), 0f);
             if (damage > 0) {
                 attackableTarget.attackEntityFrom(GTFODamageSources.EXTRACTION, damage);
-                if (attackableTarget.isDead) {
-                    attackableTarget = null;
-                }
             }
         }
     }
@@ -101,8 +95,8 @@ public class MetaTileEntityMobExtractor extends GTFOSimpleMachineMetaTileEntity 
 
         @Override
         protected void setupRecipe(@Nonnull Recipe recipe) {
-        ((MetaTileEntityMobExtractor) metaTileEntity).damageEntity(recipe);
-        super.setupRecipe(recipe);
+            ((MetaTileEntityMobExtractor) metaTileEntity).damageEntity(recipe);
+            super.setupRecipe(recipe);
         }
 
     }


### PR DESCRIPTION
Once attackableTarget is set to a non null value it will never be updated and so checkRecipe() will always return as true because of return attackableTarget != null. Can't sure for sure why it happens, but the timer in the if (this.attackableTarget == null || this.getOffsetTimer() % 5 == 0) statement would never be true which meant attackableTarget never changed. Removing the this.attackableTarget == null condition allowed the timer to check every 5 ticks and update attackableTarget.

For recipes that were suppose to deal damage, the issue was that setupAndConsumeRecipeInputs() wouldn't be called, I believe because the mob extractor doesn't have traditional inputs, and so damageEntity() would never be called either. 